### PR TITLE
WIP: Replace Symbol class with native Symbol

### DIFF
--- a/racketscript-compiler/racketscript/compiler/runtime/core/primitive.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/primitive.js
@@ -1,4 +1,5 @@
 import { hashString } from './raw_hashing.js';
+import * as Sym from './symbol.js';
 
 /**
  * Base class for various compound data types
@@ -16,13 +17,21 @@ export class Primitive {
     /** @abstract equals(*): boolean; */
 
     /**
-     * @return {!number} a 32-bit integer
-     */
+   * @return {!number} a 32-bit integer
+   */
     hashForEqual() {
         return hashString(this.toString());
     }
 }
 
 export function check(v) {
-    return (v instanceof Primitive);
+    return v instanceof Primitive;
+}
+
+// Safely get the name of a native JS Symbol
+export function safeToString(v) {
+    if (Sym.check(v)) {
+        return Sym.getValue(v);
+    }
+    return v.toString();
 }

--- a/racketscript-compiler/racketscript/compiler/runtime/core/print_native_string.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/print_native_string.js
@@ -1,6 +1,7 @@
 import * as Primitive from './primitive.js';
 import * as Bytes from './bytes.js';
 import * as Procedure from './procedure.js';
+import * as Sym from './symbol.js';
 
 /**
  * @param {!Ports.NativeStringOutputPort} out
@@ -13,6 +14,8 @@ export function displayNativeString(out, v) {
         out.consume('#f');
     } else if (v === undefined || v === null) {
         out.consume('#<void>');
+    } else if (Sym.check(v)) {
+        out.consume(Sym.getValue(v).toString());
     } else if (Primitive.check(v)) {
         v.displayNativeString(out);
     } else if (Bytes.check(v)) {
@@ -23,7 +26,7 @@ export function displayNativeString(out, v) {
         } else {
             Procedure.displayNativeString(out, v);
         }
-    } else /* if (typeof v === 'number' || typeof v === 'string') */ {
+    } /* if (typeof v === 'number' || typeof v === 'string') */ else {
         out.consume(v.toString());
     }
 }
@@ -34,14 +37,13 @@ export function displayNativeString(out, v) {
  */
 export function writeNativeString(out, v) {
     if (Primitive.check(v)) {
-        // Assume `v` implements Printable, as only Values does not,
-        // and it cannot be passed here.
+    // Assume `v` implements Printable, as only Values does not,
+    // and it cannot be passed here.
         v.writeNativeString(out);
     } else {
         displayNativeString(out, v);
     }
 }
-
 
 /**
  * @param {!Ports.NativeStringOutputPort} out

--- a/racketscript-compiler/racketscript/compiler/runtime/core/print_native_string.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/print_native_string.js
@@ -15,7 +15,7 @@ export function displayNativeString(out, v) {
     } else if (v === undefined || v === null) {
         out.consume('#<void>');
     } else if (Sym.check(v)) {
-        out.consume(Sym.getValue(v).toString());
+        out.consume(Sym.getValue(v));
     } else if (Primitive.check(v)) {
         v.displayNativeString(out);
     } else if (Bytes.check(v)) {
@@ -54,6 +54,8 @@ export function writeNativeString(out, v) {
 export function printNativeString(out, v, printAsExpression, quoteDepth) {
     if (printAsExpression && quoteDepth !== 1 && Primitive.check(v)) {
         v.printNativeString(out);
+    } else if (printAsExpression && quoteDepth !== 1 && Sym.check(v)) {
+        writeNativeString(out, `'${Sym.getValue(v)}`);
     } else if (Bytes.check(v)) {
         Bytes.printNativeString(out, v);
     } else {

--- a/racketscript-compiler/racketscript/compiler/runtime/core/print_ustring.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/print_ustring.js
@@ -2,6 +2,7 @@ import * as Primitive from './primitive.js';
 import * as Bytes from './bytes.js';
 import * as Procedure from './procedure.js';
 import * as UString from './unicode_string.js';
+import * as Sym from './symbol.js';
 
 const TRUE_USTRING = UString.makeInternedImmutable('#t');
 const FALSE_USTRING = UString.makeInternedImmutable('#f');
@@ -20,6 +21,8 @@ export function displayUString(out, v) {
         out.consume(VOID_USTRING);
     } else if (typeof v === 'number' || typeof v === 'string') {
         out.consume(UString.makeMutable(v.toString()));
+    } else if (Sym.check(v)) {
+        out.consume(UString.makeMutable(Sym.getValue(v).toString()));
     } else if (Primitive.check(v)) {
         v.displayUString(out);
     } else if (Bytes.check(v)) {
@@ -30,7 +33,7 @@ export function displayUString(out, v) {
         } else {
             out.consume(UString.makeMutable(Procedure.toString(v)));
         }
-    } else /* if (typeof v === 'number' || typeof v === 'string') */ {
+    } /* if (typeof v === 'number' || typeof v === 'string') */ else {
         out.consume(UString.makeMutable(v.toString()));
     }
 }
@@ -41,8 +44,8 @@ export function displayUString(out, v) {
  */
 export function writeUString(out, v) {
     if (Primitive.check(v)) {
-        // Assume `v` implements Printable, as only Values does not,
-        // and it cannot be passed here.
+    // Assume `v` implements Printable, as only Values does not,
+    // and it cannot be passed here.
         v.writeUString(out);
     } else {
         displayUString(out, v);

--- a/racketscript-compiler/racketscript/compiler/runtime/core/print_ustring.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/print_ustring.js
@@ -22,7 +22,7 @@ export function displayUString(out, v) {
     } else if (typeof v === 'number' || typeof v === 'string') {
         out.consume(UString.makeMutable(v.toString()));
     } else if (Sym.check(v)) {
-        out.consume(UString.makeMutable(Sym.getValue(v).toString()));
+        out.consume(UString.makeMutable(Sym.getValue(v)));
     } else if (Primitive.check(v)) {
         v.displayUString(out);
     } else if (Bytes.check(v)) {
@@ -61,6 +61,8 @@ export function writeUString(out, v) {
 export function printUString(out, v, printAsExpression, quoteDepth) {
     if (printAsExpression && quoteDepth !== 1 && Primitive.check(v)) {
         v.printUString(out);
+    } else if (printAsExpression && quoteDepth !== 1 && Sym.check(v)) {
+        writeUString(out, `'${Sym.getValue(v)}`);
     } else {
         writeUString(out, v);
     }

--- a/racketscript-compiler/racketscript/compiler/runtime/core/struct.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/struct.js
@@ -3,7 +3,11 @@ import * as $ from './lib.js';
 import { racketCoreError } from './errors.js';
 import * as Pair from './pair.js';
 import { PrintablePrimitive } from './printable_primitive.js';
-import { displayNativeString, writeNativeString, printNativeString } from './print_native_string.js';
+import {
+    displayNativeString,
+    writeNativeString,
+    printNativeString
+} from './print_native_string.js';
 import { isEqual } from './equality.js';
 import * as Values from './values.js';
 
@@ -51,9 +55,10 @@ class Struct extends PrintablePrimitive {
         // called in its constructor, hence maintaining the required
         // order
         const guardLambda = this._desc._options.guard;
-        const finalCallerName = callerName ||
-            this._desc._options.constructorName ||
-              this._desc._options.name;
+        const finalCallerName =
+      callerName ||
+      this._desc._options.constructorName ||
+      this._desc._options.name;
         if (guardLambda) {
             const guardFields = fields.concat(finalCallerName);
             const newFields = guardLambda(...guardFields);
@@ -70,23 +75,25 @@ class Struct extends PrintablePrimitive {
         if (superType !== false) {
             const superInitFields = fields.slice(0, superType._totalInitFields);
             this._fields = fields.slice(superType._totalInitFields);
-            this._superStructInstance = superType
-                .getStructConstructor(finalCallerName)(...superInitFields);
+            this._superStructInstance = superType.getStructConstructor(finalCallerName)(...superInitFields);
         } else {
             this._fields = fields;
         }
 
         // Auto fields
-        const { autoV, autoFieldCount } = this._desc._options; /* Initial value for auto fields */
+        const {
+            autoV,
+            autoFieldCount
+        } = this._desc._options; /* Initial value for auto fields */
         for (let i = 0; i < autoFieldCount; i++) {
             this._fields.push(autoV);
         }
     }
 
     /**
-     * @param {!Ports.NativeStringOutputPort} out
-     * @param {function(Ports.NativeStringOutputPort, *)} itemFn
-     */
+   * @param {!Ports.NativeStringOutputPort} out
+   * @param {function(Ports.NativeStringOutputPort, *)} itemFn
+   */
     writeToPort(out, itemFn) {
         if (this._desc._options.inspector) {
             // Not a transparent inspector
@@ -106,22 +113,22 @@ class Struct extends PrintablePrimitive {
     }
 
     /**
-     * @param {!Ports.NativeStringOutputPort} out
-     */
+   * @param {!Ports.NativeStringOutputPort} out
+   */
     displayNativeString(out) {
         this.writeToPort(out, displayNativeString);
     }
 
     /**
-     * @param {!Ports.NativeStringOutputPort} out
-     */
+   * @param {!Ports.NativeStringOutputPort} out
+   */
     writeNativeString(out) {
         this.writeToPort(out, writeNativeString);
     }
 
     /**
-     * @param {!Ports.NativeStringOutputPort} out
-     */
+   * @param {!Ports.NativeStringOutputPort} out
+   */
     printNativeString(out) {
         if (this._desc._options.inspector) {
             // Not a transparent inspector
@@ -133,8 +140,10 @@ class Struct extends PrintablePrimitive {
             for (const field of this._fields) {
                 out.consume(' ');
                 printNativeString(
-                    out, field,
-                    /* printAsExpression */ true, /* quoteDepth */ 0
+                    out,
+                    field,
+                    /* printAsExpression */ true,
+                    /* quoteDepth */ 0
                 );
             }
             out.consume(')');
@@ -177,11 +186,13 @@ class Struct extends PrintablePrimitive {
 
     setField(n, v) {
         C.truthy(
-            n < this._fields.length, racketCoreError,
+            n < this._fields.length,
+            racketCoreError,
             'invalid field at position'
         );
         C.falsy(
-            this._desc.isFieldImmutable(n), racketCoreError,
+            this._desc.isFieldImmutable(n),
+            racketCoreError,
             'field is immutable'
         );
         this._fields[n] = v;
@@ -250,8 +261,8 @@ class StructTypeDescriptor extends PrintablePrimitive {
     }
 
     /**
-     * @param {!Ports.NativeStringOutputPort} out
-     */
+   * @param {!Ports.NativeStringOutputPort} out
+   */
     displayNativeString(out) {
         out.consume('#<struct-type:');
         out.consume(this._options.name);
@@ -259,8 +270,8 @@ class StructTypeDescriptor extends PrintablePrimitive {
     }
 
     /**
-     * @param {!Ports.NativeStringOutputPort} out
-     */
+   * @param {!Ports.NativeStringOutputPort} out
+   */
     printNativeString(out) {
         this.writeNativeString(out);
     }
@@ -277,7 +288,7 @@ class StructTypeDescriptor extends PrintablePrimitive {
         const structfn = function (...args) {
             // Struct object is also a procedure
             let proc;
-            if (typeof (procSpec) === 'function') {
+            if (typeof procSpec === 'function') {
                 proc = procSpec;
                 // Structure object is sent only when procSpec is
                 // function, not when we get procedure from field.
@@ -285,8 +296,7 @@ class StructTypeDescriptor extends PrintablePrimitive {
             } else if (Number.isInteger(procSpec)) {
                 proc = structObject.getField(procSpec);
             } else {
-                throw new Error(`ValueError: invalid field at position ${
-                    procSpec}`);
+                throw new Error(`ValueError: invalid field at position ${procSpec}`);
             }
             return proc(...args);
         };
@@ -297,84 +307,102 @@ class StructTypeDescriptor extends PrintablePrimitive {
     maybeStructObject(s) {
         if (s instanceof Struct) {
             return s;
-        } else if (s instanceof Function &&
-            (s.__rjs_struct_object instanceof Struct)) {
+        } else if (
+            s instanceof Function &&
+      s.__rjs_struct_object instanceof Struct
+        ) {
             return s.__rjs_struct_object;
         }
         return false;
     }
 
     getStructConstructor(subtype = false) {
-        // subtype: Name of subtype which is used to call the constructor
-        //   returned here.
-        return $.attachReadOnlyProperty((...args) => {
-            const structObject = new Struct(this, args, subtype);
-            const hasPropProc = this._propProcedure !== undefined &&
-                this._propProcedure !== false;
-            const hasProcSpec = this._options.procSpec !== undefined &&
-                this._options.procSpec !== false;
+    // subtype: Name of subtype which is used to call the constructor
+    //   returned here.
+        return $.attachReadOnlyProperty(
+            (...args) => {
+                const structObject = new Struct(this, args, subtype);
+                const hasPropProc =
+          this._propProcedure !== undefined && this._propProcedure !== false;
+                const hasProcSpec =
+          this._options.procSpec !== undefined &&
+          this._options.procSpec !== false;
 
-            if (!hasPropProc && !hasProcSpec) {
-                return structObject;
-            } else if (hasPropProc) {
+                if (!hasPropProc && !hasProcSpec) {
+                    return structObject;
+                } else if (hasPropProc) {
+                    return this.getApplicableStructObject(
+                        structObject,
+                        this._propProcedure
+                    );
+                }
                 return this.getApplicableStructObject(
                     structObject,
-                    this._propProcedure
+                    this._options.procSpec
                 );
-            }
-            return this.getApplicableStructObject(
-                structObject,
-                this._options.procSpec
-            );
-        }, 'racketProcedureType', 'struct-constructor');
+            },
+            'racketProcedureType',
+            'struct-constructor'
+        );
     }
 
     getStructPredicate() {
-        return $.attachReadOnlyProperty((s) => {
-            const structObject = this.maybeStructObject(s);
-            return structObject &&
-                structObject._maybeFindSuperInstance(this) && true;
-        }, 'racketProcedureType', 'struct-predicate');
+        return $.attachReadOnlyProperty(
+            (s) => {
+                const structObject = this.maybeStructObject(s);
+                return (
+                    structObject && structObject._maybeFindSuperInstance(this) && true
+                );
+            },
+            'racketProcedureType',
+            'struct-predicate'
+        );
     }
 
     getStructAccessor() {
-        return $.attachReadOnlyProperty((s, pos) => {
-            const structObject = this.maybeStructObject(s);
-            if (!structObject) {
-                C.raise(
-                    TypeError,
-                    `(${s} : ${typeof (s)} != ${
-                        this._options.name} object)`
-                );
-            }
+        return $.attachReadOnlyProperty(
+            (s, pos) => {
+                const structObject = this.maybeStructObject(s);
+                if (!structObject) {
+                    C.raise(
+                        TypeError,
+                        `(${s} : ${typeof s} != ${this._options.name} object)`
+                    );
+                }
 
-            const sobj = structObject._maybeFindSuperInstance(this);
-            if (sobj === false) {
-                C.raise(racketCoreError, 'accessor applied to invalid type');
-            }
+                const sobj = structObject._maybeFindSuperInstance(this);
+                if (sobj === false) {
+                    C.raise(racketCoreError, 'accessor applied to invalid type');
+                }
 
-            return sobj.getField(pos);
-        }, 'racketProcedureType', 'struct-accessor');
+                return sobj.getField(pos);
+            },
+            'racketProcedureType',
+            'struct-accessor'
+        );
     }
 
     getStructMutator() {
-        return $.attachReadOnlyProperty((s, pos, v) => {
-            const structObject = this.maybeStructObject(s);
-            if (!structObject) {
-                C.raise(
-                    TypeError,
-                    `(${s} : ${typeof (s)} != ${
-                        this._options.name} object)`
-                );
-            }
+        return $.attachReadOnlyProperty(
+            (s, pos, v) => {
+                const structObject = this.maybeStructObject(s);
+                if (!structObject) {
+                    C.raise(
+                        TypeError,
+                        `(${s} : ${typeof s} != ${this._options.name} object)`
+                    );
+                }
 
-            const sobj = structObject._maybeFindSuperInstance(this);
-            if (sobj === false) {
-                C.raise(racketCoreError, 'mutator applied to invalid type');
-            }
+                const sobj = structObject._maybeFindSuperInstance(this);
+                if (sobj === false) {
+                    C.raise(racketCoreError, 'mutator applied to invalid type');
+                }
 
-            return sobj.setField(pos, v);
-        }, 'racketProcedureType', 'struct-mutator');
+                return sobj.setField(pos, v);
+            },
+            'racketProcedureType',
+            'struct-mutator'
+        );
     }
 
     // Find value associated with property `prop` or return `undefined`
@@ -420,8 +448,8 @@ class StructTypeProperty extends PrintablePrimitive {
     }
 
     /**
-     * @param {!Ports.NativeStringOutputPort} out
-     */
+   * @param {!Ports.NativeStringOutputPort} out
+   */
     displayNativeString(out) {
         out.consume('#<struct-type-property:');
         out.consume(this._name);
@@ -429,8 +457,8 @@ class StructTypeProperty extends PrintablePrimitive {
     }
 
     /**
-     * @param {!Ports.NativeStringOutputPort} out
-     */
+   * @param {!Ports.NativeStringOutputPort} out
+   */
     printNativeString(out) {
         this.writeNativeString(out);
     }
@@ -451,7 +479,8 @@ class StructTypeProperty extends PrintablePrimitive {
     }
 
     getPropertyAccessor() {
-        return (v) => { /* property acccessor */
+        return (v) => {
+            /* property acccessor */
             let desc;
             if (v instanceof StructTypeDescriptor) {
                 desc = v;
@@ -461,8 +490,10 @@ class StructTypeProperty extends PrintablePrimitive {
                 C.raise(racketCoreError, 'invalid argument to accessor');
             }
 
-            return desc._findProperty(this) ||
-                C.raise(racketCoreError, 'property not in struct');
+            return (
+                desc._findProperty(this) ||
+        C.raise(racketCoreError, 'property not in struct')
+            );
         };
     }
 
@@ -529,8 +560,10 @@ export function structTypeInfo(desc) {
 }
 
 export function isStructInstance(v) {
-    return (v instanceof Struct) ||
-        (v instanceof Function) && (v.__rjs_struct_object instanceof Struct);
+    return (
+        v instanceof Struct ||
+    (v instanceof Function && v.__rjs_struct_object instanceof Struct)
+    );
 }
 
 export function check(v, desc) {

--- a/racketscript-compiler/racketscript/compiler/runtime/core/symbol.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/symbol.js
@@ -1,53 +1,36 @@
-import { PrintablePrimitive } from './printable_primitive.js';
-import { internedMake } from './lib.js';
+// Create interned Symbol (Symbol.for)
+export const make = v => Symbol.for(v ? v.toString() : '');
 
-class Symbol extends PrintablePrimitive {
-    constructor(v) {
-        super();
-        this.v = v;
-        this._cachedHashCode = null;
-    }
-
-    /**
-     * @param {!Ports.NativeStringOutputPort} out
-     */
-    displayNativeString(out) {
-        out.consume(this.v);
-    }
-
-    equals(v) {
-        // Symbols are interned by default, and two symbols
-        // with same name can't be unequal.
-        // Eg. (define x (gensym)) ;;=> 'g60
-        //     (equal? x 'g60)     ;;=> #f
-        // TODO: does this handle uninterned symbols?
-        return v === this;
-    }
-
-    lt(v) {
-        if (v === this) {
-            return false;
-        }
-        return this.v < v.v;
-    }
-
-    /**
-     * @return {!number}
-     */
-    hashForEqual() {
-        if (this._cachedHashCode === null) {
-            this._cachedHashCode = super.hashForEqual();
-        }
-        return this._cachedHashCode;
-    }
-}
-
-
-export const make = internedMake(v => new Symbol(v.toString()));
-
-// TODO: is it correct to convert toString()?
-export const makeUninterned = v => new Symbol(v.toString());
+// Create uninterned Symbol
+export const makeUninterned = v => Symbol(v ? v.toString() : '');
 
 export function check(v) {
-    return (v instanceof Symbol);
+    return typeof v === 'symbol';
+}
+
+// Only interned Symbols (Symbol.for) will have a keyFor
+export function isInterned(v) {
+    return Boolean(Symbol.keyFor(v));
+}
+
+// Compares that two Symbols are equal. Only interned symbols
+// will pass.
+export function equals(s, v) {
+    if (check(s) && check(v)) {
+        return s === v;
+    }
+    return false;
+}
+
+// Can only get the value of interned Symbols (Symbol.for)
+// Ex: Symbol.keyFor(Symbol.for("foo")) === "foo"
+export function getValue(s) {
+    return Symbol.keyFor(s);
+}
+
+export function lt(s, v) {
+    if (check(s) && check(v)) {
+        return getValue(s) < getValue(v);
+    }
+    return false;
 }

--- a/racketscript-compiler/racketscript/compiler/runtime/kernel.rkt
+++ b/racketscript-compiler/racketscript/compiler/runtime/kernel.rkt
@@ -820,15 +820,13 @@
       result)))
 
 (define-checked+provide (symbol-interned? [sym symbol?])
-  ;;NOTE: We simply check if given symbol is equal to an
-  ;; interned symbol.
-  (binop === sym (#js.Core.Symbol.make #js.sym.v)))
+  (#js.Core.Symbol.isInterned sym))
 
 (define+provide (symbol=? s v)
-  (#js.s.equals v))
+  (#js.Core.Symbol.equals s v))
 
 (define+provide (symbol<? s v)
-  (#js.s.lt v))
+  (#js.Core.Symbol.lt s v))
 
 (define+provide (keyword<? s v)
   (#js.s.lt v))

--- a/racketscript-compiler/racketscript/compiler/runtime/kernel.rkt
+++ b/racketscript-compiler/racketscript/compiler/runtime/kernel.rkt
@@ -300,7 +300,7 @@
         constructor-name) #:unchecked
     ;;TODO: Add arity check
     (#js.Core.Struct.makeStructType
-     {object [name (#js.name.toString)]
+     {object [name (#js.Core.Primitive.safeToString name)]
              [superType super-type]
              [initFieldCount init-field-count]
              [autoFieldCount auto-field-count]
@@ -325,7 +325,7 @@
 (define+provide make-struct-type-property
   (v-λ (name guard supers can-impersonate?) #:unchecked
     (#js.Core.Struct.makeStructTypeProperty
-     {object [name name]
+     {object [name (#js.Core.Primitive.safeToString name)]
              [guard guard]
              [supers supers]
              [canImpersonate can-impersonate?]})))

--- a/racketscript-compiler/racketscript/compiler/runtime/kernel.rkt
+++ b/racketscript-compiler/racketscript/compiler/runtime/kernel.rkt
@@ -793,7 +793,7 @@
   (#js.Core.UString.stringToImmutableString s))
 
 (define-checked+provide (symbol->string [v symbol?])
-  (#js.Core.UString.makeMutable (#js.v.toString)))
+  (#js.Core.UString.makeMutable (#js.Core.Symbol.getValue v)))
 
 (define-checked+provide (string->symbol [s string?])
   (#js.Core.Symbol.make s))

--- a/tests/racket-core/hash.rkt
+++ b/tests/racket-core/hash.rkt
@@ -82,8 +82,9 @@
                          #"apple" 'a #"banana" 'b #"coconut" 'c
                          u/apple 'a u/banana 'b u/coconut 'c
                          ;; TODO: properly implement unreadable symbols
+                         'apple 'banana 'coconut 'coconut+
                          ; apple 'a banana 'b coconut 'c
-                         'apple 'a 'banana 'b 'coconut 'c 'coconut+ '+
+                         ;'apple 'a 'banana 'b 'coconut 'c 'coconut+ '+
                          '#:apple 'a '#:banana 'b '#:coconut 'c
                          null 'one
                          (void) 'one
@@ -405,7 +406,7 @@
     
     ;; everything ok
     ;; TODO: iterator in javascript is not currently number index
-;;    (test #t number? i)
+    ;;    (test #t number? i)
     (test #t list? (hash-iterate-key ht i))
     (test #t equal? (hash-iterate-value ht i) 'val)
     (run-if-version "6.4.0.5"


### PR DESCRIPTION
Fixes #246

⚠️ **Very exploratory**

Reference: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol)

Swaps in native Symbol to provide interned (`Symbol.for()`) and uninterned (`Symbol()`) symbols. `/runtime/core/symbol.js` is now mostly a collection of utils to create and compare values.

JS Symbols print like "Symbol(foo)" when `.toString` is called on them. To correctly pass the integration tests and mimic Racket's printing behavior we need to pull the value from interned Symbols and display that instead. This adds some utils to make it easier to check if a value is a `Symbol` and correctly return the type of string we want to use in display.

## Notes

- Because native `Symbol`s don't implement many of the methods from `Primitive` and friends we have to do a lot of special checks in lots of different places (ex: `struct.js`). Is this "ok" or should we consider wrapping the interned `Symbols` in an interface anyway to handle printing issues?
- I didn't change the way the transforms treat `symbol?` as my first swing at it caused a lot of issues. We can always go back and re-consider.