### PR TITLE
Adds bitwise-and, bitwise-ior, bitwise-xor, bitwise-not

### DIFF
--- a/racketscript-compiler/racketscript/compiler/runtime/core/numbers.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/numbers.js
@@ -72,3 +72,21 @@ export function equals(...operands) {
 export function check(v) {
     return typeof v === 'number';
 }
+
+/* Bitwise operators */
+
+export function bitwiseOr(...operands) {
+    return [].reduce.call(operands, (a, b) => a | b, 0);
+}
+
+export function bitwiseXor(...operands) {
+    return [].reduce.call(operands, (a, b) => a ^ b, 0);
+}
+
+export function bitwiseAnd(...operands) {
+    return [].reduce.call(operands, (a, b) => a & b, -1);
+}
+
+export function bitwiseNot(v) {
+    return ~v;
+}

--- a/racketscript-compiler/racketscript/compiler/runtime/kernel.rkt
+++ b/racketscript-compiler/racketscript/compiler/runtime/kernel.rkt
@@ -172,6 +172,24 @@
 (define-checked+provide (numerator [x number?]) x)
 (define-checked+provide (denominator [x number?]) 1)
 
+;; bitwise operators
+(define+provide bitwise-and
+  (#js.Core.attachProcedureName
+   (#js.Core.attachProcedureArity #js.Core.Number.bitwiseAnd 1)
+   "bitwise-and"))
+
+(define+provide bitwise-ior
+  (#js.Core.attachProcedureName
+   (#js.Core.attachProcedureArity #js.Core.Number.bitwiseOr 1)
+   "bitwise-ior"))
+
+(define+provide bitwise-xor
+  (#js.Core.attachProcedureName
+   (#js.Core.attachProcedureArity #js.Core.Number.bitwiseXor 1)
+   "bitwise-xor"))
+
+(define-checked+provide (bitwise-not [v number?])
+  (#js.Core.Number.bitwiseNot v))
 
 ;; ----------------------------------------------------------------------------
 ;; Booleans

--- a/tests/basic/arithmatic.rkt
+++ b/tests/basic/arithmatic.rkt
@@ -53,3 +53,13 @@
 
 (displayln (+))
 (displayln (*))
+
+;; test bitwise operations
+(displayln (bitwise-and 5 3)) ;; 1
+(displayln (bitwise-and 5 3 -1983)) ;; 1
+(displayln (bitwise-ior 5 3)) ;; 7
+(displayln (bitwise-ior 5 3 10)) ;; 15
+(displayln (bitwise-xor 5 3)) ;; 6
+(displayln (bitwise-xor 5 3 10)) ;; 12
+(displayln (bitwise-not 5)) ;; -6
+(displayln (bitwise-not -3)) ;; 2


### PR DESCRIPTION
These [bitwise operators](https://docs.racket-lang.org/reference/generic-numbers.html#%28part._.Bitwise_.Operations%29) were missing from kernel.rkt. Adds tests to `basic/arithmatic/rkt`.