### PR TITLE
Allow for `#f` default value

### DIFF
--- a/racketscript-compiler/racketscript/compiler/runtime/kernel.rkt
+++ b/racketscript-compiler/racketscript/compiler/runtime/kernel.rkt
@@ -394,6 +394,7 @@
 (define-checked+provide (vector->immutable-vector [vec vector?])
   (#js.Core.Vector.copy vec #f))
 
+
 ;; --------------------------------------------------------------------------
 ;; Hashes
 

--- a/racketscript-compiler/racketscript/compiler/runtime/kernel.rkt
+++ b/racketscript-compiler/racketscript/compiler/runtime/kernel.rkt
@@ -369,7 +369,10 @@
 
 ;; v is optional
 (define-checked+provide (make-vector [size integer?] [v #t])
-  (#js.Core.Vector.makeInit size (or v 0)))
+  (#js.Core.Vector.makeInit size
+    (if (eq? v *undefined*)
+      0
+      v)))
 
 (define+provide vector? #js.Core.Vector.check)
 

--- a/tests/basic/vector.rkt
+++ b/tests/basic/vector.rkt
@@ -21,3 +21,10 @@
 (displayln "equal")
 (displayln (equal? #(1 2 3) #(1 2 3)))
 (displayln (equal? #(1 2 3) #(2 2 3)))
+
+(displayln "make-vector")
+(displayln (make-vector 5))
+(displayln (make-vector 5 3))
+(displayln (make-vector 5 #f))
+(displayln (make-vector 0))
+


### PR DESCRIPTION
Fixes #252.

Previously, if the default value provided to `make-vector` was falsey, the vector would be populated with `0`. Now this will only happen if the default value is `undefined`.

If we wanted to enable a developer to populate a vector with `undefined`, we'd have to be able to detect if a value was passed in to the function or not. We could do so by accessing `arguments` directly if we feel like this is something a user should be able to do. 

As an addendum, even though `kernel.rkt` is enormous, might still be good to create a test submodule and throw things in there as people modify it.