### PR TITLE
Compile Linklets to Javascript

### DIFF
--- a/racketscript-compiler/racketscript/compiler/absyn.rkt
+++ b/racketscript-compiler/racketscript/compiler/absyn.rkt
@@ -5,6 +5,8 @@
 
 (provide (all-defined-out))
 
+(struct Linklet ([forms : (Listof GeneralTopLevelForm)]))
+
 (struct Module  ([id      : Symbol]
                  [path    : Path]
                  [lang    : (U Symbol String (Listof Symbol))]

--- a/racketscript-compiler/racketscript/compiler/absyn.rkt
+++ b/racketscript-compiler/racketscript/compiler/absyn.rkt
@@ -5,7 +5,10 @@
 
 (provide (all-defined-out))
 
-(struct Linklet ([forms : (Listof GeneralTopLevelForm)]))
+(struct Linklet ([path    : Path]
+                 [forms   : (Listof GeneralTopLevelForm)]
+                 [imports : (Setof (U Path Symbol))])
+  #:transparent)
 
 (struct Module  ([id      : Symbol]
                  [path    : Path]

--- a/racketscript-compiler/racketscript/compiler/assembler.rkt
+++ b/racketscript-compiler/racketscript/compiler/assembler.rkt
@@ -16,6 +16,7 @@
 
 (provide assemble
          assemble-module
+         assemble-linklet
          assemble-statement*
          assemble-statement)
 
@@ -58,7 +59,7 @@
          [(list? args) (map normalize-symbol args)]
          [(cons? args) (append1 (map normalize-symbol (car args))
                                 (~a "..." (normalize-symbol (cdr args))))]
-         [else (error 'assemble-expr "λ must be unchecked by assembler phase")]))
+         [else (displayln args) (error 'assemble-expr "λ must be unchecked by assembler phase")]))
      (emit (string-join args-str ", "))
      (emit ") {")
      (for ([s body])
@@ -233,6 +234,16 @@
        (when (ILLambda? stmt)
          (emit ")"))
        (emit ";")]))
+
+(: assemble-linklet (-> ILLinklet Void))
+(define (assemble-linklet lnk)
+  (match-define (ILLinklet requires body) lnk)
+  (log-rjs-info "[assemble linklet]")
+
+  (define out (open-output-file "foo.js" #:exists 'replace))
+  (assemble-requires* requires out)
+  (for ([b body])
+    (assemble-statement b out)))
 
 (: assemble-module (-> ILModule (Option Output-Port) Void))
 (define (assemble-module mod maybeout)

--- a/racketscript-compiler/racketscript/compiler/expand.rkt
+++ b/racketscript-compiler/racketscript/compiler/expand.rkt
@@ -425,13 +425,15 @@
     [_
      (error 'convert "bad ~a ~a" mod (syntax->datum mod))]))
 
-(define (convert-linklet linklet)
+(define (convert-linklet linklet path)
   (syntax-parse linklet #;(freshen-linklet-forms linklet)
     #:literal-sets () ;; what are these literal sets for?
     [(linklet _imports _exports forms ...)
-     (parameterize ([lexical-bindings (make-free-id-table)])
-       (let ([contents (filter-map to-absyn (syntax->list #'(forms ...)))])
-         (Linklet contents)))]))
+     (parameterize ([current-module-imports (set)]
+                    [lexical-bindings (make-free-id-table)])
+       (let ([contents (filter-map to-absyn (syntax->list #'(forms ...)))]
+             [imports (current-module-imports)])
+         (Linklet path contents imports)))]))
 
 (define (freshen-mod-forms mod)
   (syntax-parse mod

--- a/racketscript-compiler/racketscript/compiler/expand.rkt
+++ b/racketscript-compiler/racketscript/compiler/expand.rkt
@@ -268,6 +268,7 @@
                (current-module-imports (set-add (current-module-imports) '#%kernel))
                (current-module-imports (set-add (current-module-imports) src-mod-path)))
 
+
            ;;HACK: See test/struct/import-struct.rkt. Somehow, the
            ;;  struct constructor has different src-id returned by
            ;;  identifier-binding than the actual identifier name used
@@ -428,7 +429,9 @@
   (syntax-parse linklet #;(freshen-linklet-forms linklet)
     #:literal-sets () ;; what are these literal sets for?
     [(linklet _imports _exports forms ...)
-     (Linklet (filter-map to-absyn (syntax->list #'(forms ...))))]))
+     (parameterize ([lexical-bindings (make-free-id-table)])
+       (let ([contents (filter-map to-absyn (syntax->list #'(forms ...)))])
+         (Linklet contents)))]))
 
 (define (freshen-mod-forms mod)
   (syntax-parse mod

--- a/racketscript-compiler/racketscript/compiler/il-analyze.rkt
+++ b/racketscript-compiler/racketscript/compiler/il-analyze.rkt
@@ -45,7 +45,7 @@
      (define pos-formals (cast (car formals*) (Listof Symbol)))
      (list (check-arity-stm '< (length pos-formals)))]))
 
-(: insert-arity-checks (-> ILModule ILModule))
+(: insert-arity-checks (-> (U ILLinklet ILModule) (U ILLinklet ILModule)))
 (define (insert-arity-checks mod)
   (: traverse-expr (-> ILExpr ILExpr))
   (define traverse-expr
@@ -121,8 +121,11 @@
   (define (traverse-stm* stm*)
     (map traverse-stm stm*))
 
-  (match-define (ILModule id provides requires body) mod)
-  (ILModule id provides requires (traverse-stm* body)))
+  (match mod
+    [(ILModule id provides requires body)
+     (ILModule id provides requires (traverse-stm* body))]
+    [(ILLinklet requires body)
+     (ILLinklet requires (traverse-stm* body))]))
 
 ;; ----------------------------------------------------------------------------
 ;; Tail Call Optimization

--- a/racketscript-compiler/racketscript/compiler/il.rkt
+++ b/racketscript-compiler/racketscript/compiler/il.rkt
@@ -16,6 +16,9 @@
 (define-predicate   ILProgram? ILProgram)
 (define-type-alias  ILModuleName (Option Path-String))
 
+(struct ILLinklet ([requires : ILRequire*]
+                   [body     : ILStatement*]))
+
 (struct ILModule ([id       : ILModuleName]
                   [provides : ILProvide*]
                   [requires : ILRequire*]

--- a/racketscript-compiler/racketscript/compiler/main.rkt
+++ b/racketscript-compiler/racketscript/compiler/main.rkt
@@ -422,8 +422,11 @@
           (get-output-string output-string)))]
     ['complete (racket->js)]
     ['linklet
+     (define p (path->complete-path (main-source-file)))
+     (current-source-file p)
      (~> (expand-linklet source)
-         (convert-linklet _)
+         (convert-linklet _ p)
+         (absyn-linklet->il _)
          (pretty-print _))])
 
   (void))

--- a/racketscript-compiler/racketscript/compiler/main.rkt
+++ b/racketscript-compiler/racketscript/compiler/main.rkt
@@ -391,10 +391,6 @@
       [else
        (quick-expand source)]))
 
-  (define (expanded-linklet)
-    (parameterize ([current-namespace (make-base-namespace)])
-
-
   (match (build-mode)
     ['expand (~> (expanded-module)
                  (syntax->datum _)
@@ -421,7 +417,7 @@
           (get-output-string output-string)))]
     ['complete (racket->js)]
     ['linklet
-     (~> (expanded-module)
+     (~> (expand-linklet source)
          (convert-linklet _)
          (pretty-print _))])
 

--- a/racketscript-compiler/racketscript/compiler/main.rkt
+++ b/racketscript-compiler/racketscript/compiler/main.rkt
@@ -363,7 +363,9 @@
   (unless (equal? (build-mode) 'js)
     (log-rjs-info "RacketScript root directory: ~a" racketscript-dir))
 
-  (unless (or (input-from-stdin?) (equal? (build-mode) 'linklet))
+  (define linklet-mode? (equal? (build-mode) 'linklet))
+
+  (unless (or (input-from-stdin?) linklet-mode?)
     ;; Initialize global-export-graph so that we can import each module as an
     ;; object and follow identifier's from there. For stdin builds, we have to
     ;; defer this operation.
@@ -371,6 +373,9 @@
       ;; As 'js mode prints output to stdout, we don't want to mix
       (log-rjs-info "Resolving module dependencies and identifiers... "))
     (global-export-graph (get-export-tree (list source))))
+
+  (when linklet-mode?
+    (global-export-graph (get-export-tree (list (collection-file-path "base.rkt" "racket")))))
 
   (define (expanded-module)
     (cond

--- a/racketscript-compiler/racketscript/compiler/main.rkt
+++ b/racketscript-compiler/racketscript/compiler/main.rkt
@@ -324,6 +324,7 @@
    ["--ast" "Expand and print AST" (build-mode 'absyn)]
    ["--il" "Compile to intermediate langauge (IL)" (build-mode 'il)]
    ["--js" "Compile and print JS module to stdout" (build-mode 'js)]
+   ["--linklet" "Compile a linklet as an s-expression to JS and print to stdout" (build-mode 'linklet)]
    ["--complete" "Compile module and its dependencies to JS" (build-mode 'complete)]
    #:args ([filename 'stdin])
    (match `(,filename ,(input-from-stdin?))
@@ -362,7 +363,7 @@
   (unless (equal? (build-mode) 'js)
     (log-rjs-info "RacketScript root directory: ~a" racketscript-dir))
 
-  (unless (input-from-stdin?)
+  (unless (or (input-from-stdin?) (equal? (build-mode) 'linklet))
     ;; Initialize global-export-graph so that we can import each module as an
     ;; object and follow identifier's from there. For stdin builds, we have to
     ;; defer this operation.

--- a/racketscript-compiler/racketscript/compiler/main.rkt
+++ b/racketscript-compiler/racketscript/compiler/main.rkt
@@ -391,6 +391,10 @@
       [else
        (quick-expand source)]))
 
+  (define (expanded-linklet)
+    (parameterize ([current-namespace (make-base-namespace)])
+
+
   (match (build-mode)
     ['expand (~> (expanded-module)
                  (syntax->datum _)
@@ -415,6 +419,10 @@
       (if (js-output-beautify?)
           (js-string-beautify (get-output-string output-string))
           (get-output-string output-string)))]
-    ['complete (racket->js)])
+    ['complete (racket->js)]
+    ['linklet
+     (~> (expanded-module)
+         (convert-linklet _)
+         (pretty-print _))])
 
   (void))

--- a/racketscript-compiler/racketscript/compiler/main.rkt
+++ b/racketscript-compiler/racketscript/compiler/main.rkt
@@ -423,10 +423,13 @@
     ['complete (racket->js)]
     ['linklet
      (define p (path->complete-path (main-source-file)))
+     (displayln p)
      (current-source-file p)
      (~> (expand-linklet source)
          (convert-linklet _ p)
          (absyn-linklet->il _)
+         (insert-arity-checks _)
+         (assemble-linklet _)
          (pretty-print _))])
 
   (void))

--- a/stuff.rkt
+++ b/stuff.rkt
@@ -1,0 +1,6 @@
+#lang racket/base
+
+(+ 2 3)
+
+38
+


### PR DESCRIPTION
@stchang 

We would like to eliminate the server requirement for editing Racketscript online. To do that, we need to be able to run the Racketscript compiler itself (and more importantly, the Racket expander) in the browser.

The first step in achieving this is compiling linklets to javascript. The expander can compile itself to one, so this is the first milestone in the bootstrapping process.

Warning: the code is a mess. The code was written under the (reasonable) assumption that there wouldn't be another module-like entity to compile, but I've skipped refactoring any of that at the moment.