### PR TITLE
`prop:sealed` support

### DIFF
--- a/racketscript-compiler/racketscript/compiler/runtime/core/struct.js
+++ b/racketscript-compiler/racketscript/compiler/runtime/core/struct.js
@@ -503,7 +503,7 @@ class StructTypeProperty extends PrintablePrimitive {
     }
 
     _isSealedProperty() {
-        return this._name === "prop:sealed";
+        return this._name === 'prop:sealed';
     }
 }
 

--- a/racketscript-compiler/racketscript/compiler/runtime/kernel.rkt
+++ b/racketscript-compiler/racketscript/compiler/runtime/kernel.rkt
@@ -1021,6 +1021,7 @@
 (define-property+provide prop:authentic)
 (define-property+provide prop:serialize)
 (define-property+provide prop:custom-write)
+(define-property+provide prop:sealed)
 
 (define+provide prop:procedure #js.Core.Struct.propProcedure)
 (define+provide prop:equal+hash #js.Core.Struct.propEqualHash)


### PR DESCRIPTION
Adds `prop:sealed` as a struct type property, as well as implementing its semantics (no other struct type can have a sealed struct type as super). 

This property is used in the expander linklet.