### PR TITLE
Add #lang racketscript

### DIFF
--- a/racketscript-compiler/racketscript/lang/reader.rkt
+++ b/racketscript-compiler/racketscript/lang/reader.rkt
@@ -1,0 +1,6 @@
+#lang s-exp syntax/module-reader
+racketscript
+
+#:read x-read
+#:read-syntax x-read-syntax
+(require "../boot/lang/reader.rkt")

--- a/tests/ffi/for-array.rkt
+++ b/tests/ffi/for-array.rkt
@@ -1,4 +1,4 @@
-#lang racketscript/base
+#lang racketscript
 
 (require racketscript/interop)
 


### PR DESCRIPTION
This PR adds the ability to use `#lang racketscript`. It's the same as doing `#lang racketscript/base` for now but can be extended later. This closes issue #242. 

I couldn't come up with a way to test `#lang racketscript` by itself in a way that cleanly fit the 'tests' folder organization. Instead I changed the `#lang racketscript/base` in 'tests/ffi/for-array.rkt' to `#lang racketscript` and confirmed that the test still passed. If there's a better way of testing this, please let me know.