### PR TITLE
Fix stale dependency compilation issue.

### DIFF
--- a/racketscript-compiler/racketscript/compiler/main.rkt
+++ b/racketscript-compiler/racketscript/compiler/main.rkt
@@ -245,6 +245,11 @@
   (for ([pm primitive-modules])
     (put-to-pending! pm))
 
+  ;; Add stale modules to the compile queue.
+  (for ([(mod timestamp) timestamps])
+    (when (not (skip-module-compile? timestamps mod))
+      (put-to-pending! mod)))
+
   (let loop ()
     (define next (and (non-empty-queue? pending) (dequeue! pending)))
     (cond

--- a/tests/dep-cache/has-dependency.rkt
+++ b/tests/dep-cache/has-dependency.rkt
@@ -1,0 +1,10 @@
+#lang racket
+
+;; Tests dependecy caching by compiling once, then swapping
+;; the names of ./private/dependency.rkt and ./private/depndency-changed.rkt,
+;; then compiling again. If dependency caching isn't working properly, there
+;; will be an error on the second compilation.
+
+(require "./private/dependency.rkt")
+
+(println (format "~a" (add 5)))

--- a/tests/dep-cache/private/dependency.rkt
+++ b/tests/dep-cache/private/dependency.rkt
@@ -1,0 +1,6 @@
+#lang racket
+
+(provide add)
+
+(define (add n)
+  (+ n 2))


### PR DESCRIPTION
Fixes the issue where a stale dependency is not recompiled if the dependent file hasn't changed. It does this by checking all cached timestamps for stale files before the main compilation loop, instead of doing it in flight.

This resolves issue #313.

I'm having some trouble writing a test case for this code. There's a difference between the main compiler and the test fixture that causes this issue to crop up in tests despite the fix.  When using `racks`, this fix produces the desired behavior. I'll push another commit and update this pull request once I have a working test case.