### PR TITLE
Add support for Racket 8.7

### DIFF
--- a/.github/workflows/racket.yml
+++ b/.github/workflows/racket.yml
@@ -14,19 +14,32 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        racket-version: [ '6.12', '7.0', '7.4', '7.5', '7.6', '7.7', '7.8' ]
-        racket-variant: [ 'BC' ]
-        experimental: [false]
+        racket-version: [ '8.0', '8.1', '8.2', '8.3', '8.4',
+                          '8.5', '8.6', '8.7', 'current']
+        racket-variant: [ 'CS' ]
+        experimental: [true]
         include:
-          - racket-version: '8.0'
-            racket-variant: 'CS'
-            experimental: true
-          - racket-version: '8.1'
-            racket-variant: 'CS'
-            experimental: true
-          - racket-version: 'current'
-            racket-variant: 'CS'
-            experimental: true
+          - racket-version: '6.12'
+            racket-variant: 'BC'
+            experimental: false
+          - racket-version: '7.0'
+            racket-variant: 'BC'
+            experimental: false
+          - racket-version: '7.4'
+            racket-variant: 'BC'
+            experimental: false
+          - racket-version: '7.5'
+            racket-variant: 'BC'
+            experimental: false
+          - racket-version: '7.6'
+            racket-variant: 'BC'
+            experimental: false
+          - racket-version: '7.7'
+            racket-variant: 'BC'
+            experimental: false
+          - racket-version: '7.8'
+            racket-variant: 'BC'
+            experimental: false
     name: Racket ${{ matrix.racket-version }} ${{ matrix.racket-variant }}
     steps:
       - uses: actions/checkout@master

--- a/racketscript-compiler/racketscript/compiler/runtime/kernel.rkt
+++ b/racketscript-compiler/racketscript/compiler/runtime/kernel.rkt
@@ -197,6 +197,8 @@
 (define-checked+provide (bitwise-not [v number?])
   (#js.Core.Number.bitwiseNot v))
 
+(define+provide (bitwise-bit-set? n m)
+  (not (zero? (bitwise-and n (arithmetic-shift 1 m)))))
 ;; ----------------------------------------------------------------------------
 ;; Booleans
 
@@ -1033,6 +1035,7 @@
 (define-property+provide prop:serialize)
 (define-property+provide prop:custom-write)
 (define-property+provide prop:sealed)
+(define-property+provide prop:object-name)
 
 (define+provide prop:procedure #js.Core.Struct.propProcedure)
 (define+provide prop:equal+hash #js.Core.Struct.propEqualHash)
@@ -1219,8 +1222,6 @@
   (v-λ (x n)
        "str" #;(#js.x.toString)))
 
-(define+provide (procedure-arity-mask fn) (procedure-arity fn))
-(define+provide (bitwise-bit-set? mask n) #t)
 (define+provide (procedure-extract-target f) #f)
 
 ;; --------------------------------------------------------------------------
@@ -1299,6 +1300,14 @@
                (or (exact-nonnegative-integer? v)
                    (kernel:arity-at-least? v)))
              v)))
+
+(define+provide (procedure-arity-mask fn)
+  (let ([ar (procedure-arity fn)])
+    (cond
+      [(integer? ar)
+       (arithmetic-shift 1 ar)]
+      [(kernel:arity-at-least? ar)
+       (arithmetic-shift -1 (kernel:arity-at-least-value ar))])))
 
 (define+provide (checked-procedure-check-and-extract type v proc v1 v2)
   (cond

--- a/racketscript-compiler/racketscript/compiler/transform.rkt
+++ b/racketscript-compiler/racketscript/compiler/transform.rkt
@@ -606,9 +606,10 @@
              (cons (ILVarDec result-id v)
                    binding-stms))]))
 
-
 (: absyn-value->il (-> Any ILExpr))
 (define (absyn-value->il d)
+  ;; Order here matters. For example, a list is always a cons
+  ;; but a cons is not always a list.
   (cond
     [(Quote? d) (absyn-value->il (Quote-datum d))]
     [(string? d)
@@ -620,11 +621,11 @@
     [(keyword? d)
      (ILApp (name-in-module 'core 'Keyword.make)
             (list (ILValue (keyword->string d))))]
+    [(empty? d)
+     (name-in-module 'core 'Pair.EMPTY)]
     [(list? d)
      (ILApp (name-in-module 'core 'Pair.makeList)
             (map absyn-value->il d))]
-    [(empty? d)
-     (name-in-module 'core 'Pair.EMPTY)]
     [(cons? d)
      (ILApp (name-in-module 'core 'Pair.make)
             (list (absyn-value->il (car d))


### PR DESCRIPTION
This PR adds support for Racket 8.7. The issue ended up being some unimplemented functions:

- procedure-arity-mask
- bitwise-bit-set?
- prop:object-name

I also reordered the `cond` expression in `transform.rkt`. I put `empty?` before `list?` because it seemed like the transformation to IL otherwise wouldn't use `Pair.EMPTY`. It wasn't causing any issues but it just didn't seem like the intended behavior.