### PR TITLE
Fix unnecessary copy to build directory

### DIFF
--- a/racketscript-compiler/racketscript/compiler/main.rkt
+++ b/racketscript-compiler/racketscript/compiler/main.rkt
@@ -265,11 +265,11 @@
       (when (js-output-beautify?)
         (system (format "js-beautify -r ~a" (module-output-file next))))
 
-      (for ([mod (in-set (Module-imports ast))])
-        (match mod
-          [(? symbol? _) (void)]
-          [_ #:when (collects-module? mod) (put-to-pending! mod)]
-          [_ (put-to-pending! mod)]))
+      (for ([mod (in-set (Module-imports ast))]
+            #:unless (or (symbol? mod)
+                         (set-member? ignored-module-imports-in-boot
+                                      mod)))
+        (put-to-pending! mod))
 
       next))
 

--- a/racketscript-compiler/racketscript/compiler/transform.rkt
+++ b/racketscript-compiler/racketscript/compiler/transform.rkt
@@ -91,8 +91,7 @@
       ;; modules
       (if (or (and (primitive-module? mod-path)  ;; a self-import cycle
                    (equal? path (actual-module-path mod-path)))
-              (and (primitive-module-path? (actual-module-path path))
-                   (set-member? ignored-module-imports-in-boot mod-path)))
+              (set-member? ignored-module-imports-in-boot mod-path))
           #f
           (ILRequire import-name mod-obj-name '*))))
 

--- a/racketscript-compiler/racketscript/compiler/util.rkt
+++ b/racketscript-compiler/racketscript/compiler/util.rkt
@@ -228,7 +228,6 @@
        (build-path (output-directory) "links" name (~a rel-path ".js")))
      ;; because we just created root links directory, but files could be
      ;; deep arbitrarily inside
-     (make-directory* (assert (path-only output-path) path?))
      ;; TODO: doesn't handle arbitrary deep files for now
      (path->complete-path output-path)]
     [(list 'general mod-path)


### PR DESCRIPTION
Fixes a bug where the private/interop module was copied to the build directory if a source file required racketscript/interop.

The racketscript/private/interop module includes the #%js-ffi function which raises an error if used in Racket. The compiler overrides this binding with js-ffi calls, so the module never actually needs to be copied to the build directory.