### PR TITLE
Fix Playground compilation issue (#324)

### DIFF
--- a/racketscript-compiler/racketscript/compiler/main.rkt
+++ b/racketscript-compiler/racketscript/compiler/main.rkt
@@ -266,11 +266,11 @@
       (when (js-output-beautify?)
         (system (format "js-beautify -r ~a" (module-output-file next))))
 
-      (for ([mod (in-set (Module-imports ast))]
-            #:unless (or (symbol? mod)
-                         (set-member? ignored-module-imports-in-boot
-                                      mod)))
-        (put-to-pending! mod))
+      (for ([mod (in-set (Module-imports ast))])
+        (match mod
+          [(? symbol? _) (void)]
+          [_ #:when (collects-module? mod) (put-to-pending! mod)]
+          [_ (put-to-pending! mod)]))
 
       next))
 

--- a/racketscript-compiler/racketscript/compiler/runtime/unsafe.rkt
+++ b/racketscript-compiler/racketscript/compiler/runtime/unsafe.rkt
@@ -23,8 +23,7 @@
 (define-unsafe-fx-binop+provide unsafe-fx+         +)
 (define-unsafe-fx-binop+provide unsafe-fx-         -)
 (define-unsafe-fx-binop+provide unsafe-fx*         *)
-(define+provide unsafe-fxquotient  (if-scheme-numbers #js.Core.Number.Scheme.divide
-                                                      #js.Core.Number.JS.divide))
+(define-unsafe-fx-binop+provide unsafe-fxquotient  /)
 (define-unsafe-fx-binop+provide unsafe-fxremainder %)
 
 (define+provide (unsafe-fxmodulo a b)

--- a/racketscript-compiler/racketscript/compiler/transform.rkt
+++ b/racketscript-compiler/racketscript/compiler/transform.rkt
@@ -91,7 +91,8 @@
       ;; modules
       (if (or (and (primitive-module? mod-path)  ;; a self-import cycle
                    (equal? path (actual-module-path mod-path)))
-              (set-member? ignored-module-imports-in-boot mod-path))
+              (and (primitive-module-path? (actual-module-path path))
+                   (set-member? ignored-module-imports-in-boot mod-path)))
           #f
           (ILRequire import-name mod-obj-name '*))))
 

--- a/racketscript-compiler/racketscript/compiler/util.rkt
+++ b/racketscript-compiler/racketscript/compiler/util.rkt
@@ -228,6 +228,7 @@
        (build-path (output-directory) "links" name (~a rel-path ".js")))
      ;; because we just created root links directory, but files could be
      ;; deep arbitrarily inside
+     (make-directory* (assert (path-only output-path) path?))
      ;; TODO: doesn't handle arbitrary deep files for now
      (path->complete-path output-path)]
     [(list 'general mod-path)


### PR DESCRIPTION
Fixes issue #324 where the racket playground wouldn't compile. Specifically, it fixes a small bug in the implementation of unsafe division. Closes #324 

It also fixes issue #326 by reverting commit https://github.com/racketscript/racketscript/commit/4dc26bae5b896da6b02d28861e47b5393739141e which attempted to prevent unnecessary copying of the `private/interop.rkt` file to the build directory. This seems to cause a bug that wasn't caught by the Racketscript test suite. Closes #326 